### PR TITLE
remove sigstore signing in auto-pypi-lublishing as this is not required

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -46,41 +46,6 @@ jobs:
       - name: publish-dist-to-pypi
         uses: pypa/gh-action-pypi-publish@release/v1
 
-  github-release:
-    name: >-
-      sign-dist-via-sigstore-and-upload-to-github-release
-    needs:
-      - publish-to-pypi
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-      id-token: write
-
-    steps:
-      - name: download-dists
-        uses: actions/download-artifact@v4
-        with:
-          name: pkg-dist
-          path: dist/
-      - name: sign-dists
-        uses: sigstore/gh-action-sigstore-python@v1.2.3
-        with:
-          inputs: >-
-            ./dist/*.tar.gz ./dist/*.whl
-      - name: create-github-release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          gh release create '${{ github.ref_name }}' --repo '${{
-          github.repository }}' --notes ""
-      - name: upload-artifact-signature-to-github-release
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: >-
-          gh release upload '${{ github.ref_name }}' dist/** --repo '${{
-          github.repository }}'
-
   publish-to-test-pypi:
     name: publish-to-test-pypi
     if: startsWith(github.ref, 'refs/heads/development')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
 [project]
 name = "CAKED"
-version = "0.1.6"  # need to also update version in src/caked/__init__.py
+version = "0.1.7"  # need to also update version in src/caked/__init__.py
 authors = [
   { name = "Bea Costa Gomes", email = "bcostagomes@turing.ac.uk" },
 ]


### PR DESCRIPTION
removing sigstore from pypi publishing workflow